### PR TITLE
Fix `forecast_validator` help example

### DIFF
--- a/R/forecast_validator.R
+++ b/R/forecast_validator.R
@@ -8,7 +8,7 @@
 #' @importFrom EML read_eml eml_validate
 #' @examples
 #'\dontrun{
-#' forecast_validator(system.file("vignettes", "forecast-eml.xml", package="EFIstandards"))
+#' forecast_validator(system.file("extdata", "forecast-eml.xml", package="EFIstandards"))
 #'}
 forecast_validator <- function(eml){
 

--- a/docs/reference/forecast_validator.html
+++ b/docs/reference/forecast_validator.html
@@ -144,7 +144,7 @@
 
     <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>
     <pre class="examples"><div class='input'><span class='kw'>if</span> (<span class='fl'>FALSE</span>) {
-<span class='fu'>forecast_validator</span>(<span class='fu'><a href='https://rdrr.io/r/base/system.file.html'>system.file</a></span>(<span class='st'>"vignettes"</span>, <span class='st'>"forecast-eml.xml"</span>, <span class='kw'>package</span><span class='kw'>=</span><span class='st'>"EFIstandards"</span>))
+<span class='fu'>forecast_validator</span>(<span class='fu'><a href='https://rdrr.io/r/base/system.file.html'>system.file</a></span>(<span class='st'>"extdata"</span>, <span class='st'>"forecast-eml.xml"</span>, <span class='kw'>package</span><span class='kw'>=</span><span class='st'>"EFIstandards"</span>))
 }</div></pre>
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="pkgdown-sidebar">

--- a/man/forecast_validator.Rd
+++ b/man/forecast_validator.Rd
@@ -17,6 +17,6 @@ EFI forecast standard EML metadata validator
 }
 \examples{
 \dontrun{
-forecast_validator(system.file("vignettes", "forecast-eml.xml", package="EFIstandards"))
+forecast_validator(system.file("extdata", "forecast-eml.xml", package="EFIstandards"))
 }
 }


### PR DESCRIPTION
Package structure looks great! I could install and run vignettes pretty easily (just some package downloads)

One small fix: the un-run example in `forecast_validator` didn't work as written